### PR TITLE
Add Dolphin and Konsole

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -10,6 +10,7 @@ BOINC Manager, boinc, Boincmgr
 CMake, CMake, CMakeSetup
 Copy, copy, CopyAgent
 Counter-Strike: Global Offensive, Counter-Strike Global Offensive, csgo_linux64
+Dolphin, org.kde.dolphin, dolphin
 Don't Starve, Don't Starve, dontstarve_steam
 Double Action: Boogaloo, Double Action Boogaloo, hl2_linux
 Etcher, Etcher, etcher
@@ -43,6 +44,7 @@ Insync, insync, Insync.py
 Intellij IDEA Community Edition, intellij-idea-community, jetbrains-idea-ce
 JDownloader ,jdownloader, JDownloader
 Kdenlive, org.kde.kdenlive, kdenlive
+Konsole, org.kde.konsole, konsole
 KRDC, org.kde.krdc, krdc
 Minecraft, minecraft, net-minecraft-bootstrap-Bootstrap
 League of Legends, playonlinux-League of Legends, LoLPatcherUx.exe


### PR DESCRIPTION
Just Added Dolphin and Konsole to the database.csv.

Tested on Manjaro Gnome. Worked just fine.